### PR TITLE
add chromebook vs code setup notes + clarify some python tutorial steps (8.4)

### DIFF
--- a/content/python/getting_started/2_code_editor/_index.md
+++ b/content/python/getting_started/2_code_editor/_index.md
@@ -23,7 +23,7 @@ Our suggestion is below, but feel free to ask your coach what their preferences 
 
 ## VS Code
 
-VS Code is a very popular and free to use editor. It's available for Windows, OS X and Linux.
+VS Code is a very popular and free to use editor. It's available for Windows, OS X and Linux. Note, if you are using a Chromebook then it will present you with a few options to download from, choose the option that has the `.deb` or `debian` and that should work for you.
 
 [Download it here](https://code.visualstudio.com/)
 

--- a/content/python/space_turtle_chomp/part_8__creating_space_and_sound.md
+++ b/content/python/space_turtle_chomp/part_8__creating_space_and_sound.md
@@ -38,16 +38,20 @@ wn.bgpic('kbgame-bg.gif')
 ```
 
 Step 4.  The space cabbages currently are the same size as your turtle lets
- makes them smaller and add a few more. You can do this by changing the
- max\_foods number and adding a the following to the for count in range section:
+ makes them smaller and add a few more. 
+ 
+You can do add more by tweaking the `maxFoods` variable that you defined earlier: 
 
 ```python
-# create food
-max_foods = 10
+# Create food
+maxFoods = 10
+```
 
+and then to change the size we loop through all the foods and set their `shapesize`:
 
+```python
 for food in foods:
-    foods.shapesize(.5)
+    food.shapesize(.5)
 ```
 
 Step 5.  Save your game as kbgame8 and run your module


### PR DESCRIPTION
- add note about picking debian package for chromebook installs of vscode
- clarify some instructions in section 8 of python content
    - fixed a syntax error in some loop code that gets copied
    - instructions seem to be referencing a previous variant of the tutorial code, cleaned it up for relevance