### PR TITLE
Fix link formatting when it contains quotation marks

### DIFF
--- a/content/python/getting_started/3_how_to_python/_index.md
+++ b/content/python/getting_started/3_how_to_python/_index.md
@@ -554,7 +554,7 @@ Congrats! Booleans are one of the coolest features in programming, and you just 
 
 # Save it!
 
-> For readers at home: this part is covered in the [Python Basics: Saving files and "If" statement](https://www.youtube.com/watch?v=dOAg6QVAxyk) video.
+> For readers at home: this part is covered in the [Python Basics: Saving files and /"If/" statement](https://www.youtube.com/watch?v=dOAg6QVAxyk) video.
 
 
 So far we've been writing all our python code in the interpreter, which limits us to entering one line of code at a time. Normal programs are saved in files and executed by our programming language __interpreter__ or __compiler__. So far we've been running our programs one line at a time in the Python __interpreter__. We're going to need more than one line of code for the next few tasks, so we'll quickly need to:


### PR DESCRIPTION
Some strange formatting with the link, has to do with Hugo's markdown. 

<img width="986" alt="image" src="https://user-images.githubusercontent.com/54166448/178222784-8895a231-09f9-4837-9ab3-2ff58edc6cca.png">
